### PR TITLE
Add Stop-Task function to cancel tasks, +semver: minor

### DIFF
--- a/OctopusDeploy/Classes/TransformerClasses.psm1
+++ b/OctopusDeploy/Classes/TransformerClasses.psm1
@@ -220,7 +220,6 @@ class ProjectTriggerSingleTransformation : System.Management.Automation.Argument
     }
 
 }
-
 class ProjectTriggerTransformation : System.Management.Automation.ArgumentTransformationAttribute {
     [object] Transform([System.Management.Automation.EngineIntrinsics]$EngineIntrinsics, [object] $InputData) {
         $result = @()
@@ -233,5 +232,16 @@ class ProjectTriggerTransformation : System.Management.Automation.ArgumentTransf
             $result += ($item)
         }
         return ($result)
+    }
+}
+class TaskSingleTransformation : System.Management.Automation.ArgumentTransformationAttribute {
+    [object] Transform([System.Management.Automation.EngineIntrinsics]$EngineIntrinsics, [object] $InputData) {
+        $item = $InputData
+        if ($item -is [string] -and $item -like "ServerTasks-*") {
+            $item = Get-Task -TaskID "$item"
+        } elseif ($item -is [string]) {
+            $item = $null
+        }
+        return ($item)
     }
 }

--- a/OctopusDeploy/Public/Stop-Task.ps1
+++ b/OctopusDeploy/Public/Stop-Task.ps1
@@ -1,0 +1,121 @@
+function Stop-Task {
+    <#
+    .SYNOPSIS
+    Cancels tasks with specified states for a project release, runbook, or other filters.
+    .DESCRIPTION
+    This function retrieves tasks using the `Get-Task` function and cancels them based on the provided parameters.
+    .PARAMETER Task
+    The task to cancel. This parameter is mandatory when using the 'byTask' parameter set.
+    .PARAMETER TaskType
+    The type of task to filter by (e.g., Deploy, RunbookRun). Optional.
+    .PARAMETER Tenant
+    The tenant to filter tasks by. Optional.
+    .PARAMETER Environment
+    The environment to filter tasks by. Optional.
+    .PARAMETER Regarding
+    The task or runbook snapshot object to filter by. Optional.
+    .PARAMETER State
+    The state of the tasks to cancel. Valid values are "Executing", "Queued" and "WaitingForManualIntervention". Defaults to all if not specified.
+    .EXAMPLE
+    Stop-Task -Task (Get-Task -TaskID "ServerTasks-1234567")
+    Cancels the task with the specified ID.
+    .EXAMPLE
+    Stop-Task -TaskType Deploy -State Executing
+    Cancels all executing deployment tasks.
+    .EXAMPLE
+    Stop-Task -Tenant $tenant -Environment $environment -State Queued
+    Cancels all queued tasks for the specified tenant and environment.
+    .EXAMPLE
+    Stop-Task -Regarding $runbookSnapshot
+    Cancels all tasks regarding the given runbook snapshot.
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false,
+            ValueFromPipelineByPropertyName = $true,
+            ParameterSetName = 'byTask')]
+        [TaskSingleTransformation()]
+        [Octopus.Client.Model.TaskResource]
+        $Task,
+
+        [Parameter(Mandatory = $false,
+            ParameterSetName = 'default')]
+        [ValidateSet("Deploy", "RunbookRun", "Health", "AdHocScript", "Upgrade", "Backup", "TentacleUpgrade", "Retention", "MachinePolicyUpdate")]
+        [string]
+        $TaskType,
+
+        [Parameter(Mandatory = $false,
+            ParameterSetName = 'default')]
+        [TenantSingleTransformation()]
+        [Octopus.Client.Model.TenantResource]
+        $Tenant,
+
+        [Parameter(Mandatory = $false,
+            ParameterSetName = 'default')]
+        [EnvironmentSingleTransformation()]
+        [Octopus.Client.Model.EnvironmentResource]
+        $Environment,
+
+        [Parameter(Mandatory = $false,
+            ValueFromPipeline = $true,
+            ParameterSetName = 'byRegarding')]
+        [ValidateNotNullOrEmpty()]
+        [Octopus.Client.Model.Resource]
+        $Regarding,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("Executing", "Queued", "WaitingForManualIntervention")]
+        [String[]]
+        $State = @("Executing", "Queued", "WaitingForManualIntervention")
+    )
+
+    begin {
+        try {
+            ValidateConnection
+        }
+        catch {
+            $PSCmdlet.ThrowTerminatingError($_)
+        }
+
+        # Initialize an empty array to store tasks to cancel
+        $tasksToCancel = @() 
+
+        # Combine states into a regex pattern
+        $stateRegex = ($State -join '|') -replace ' ', ''
+    }
+
+    process {
+        # Check the parameter set name to determine how to retrieve tasks
+        if ($PSCmdlet.ParameterSetName -eq 'byTask') {
+            # Cancel a specific task
+            $tasksToCancel += $Task
+        }
+        elseif ($PSCmdlet.ParameterSetName -eq 'byRegarding') {
+            # Cancel tasks regarding a specific object
+            foreach ($r in $Regarding) {
+                $tasksToCancel += Get-Task -Regarding $r | Where-Object { $_.State -match $stateRegex }
+            }
+        }
+        else {
+            # Retrieve tasks using Get-Task
+            $tasksToCancel = Get-Task -TaskType $TaskType -Tenant $Tenant -Environment $Environment | Where-Object { $_.State -match $stateRegex }
+        }
+
+        Write-Verbose "Found $($tasksToCancel.Count) tasks to cancel."
+
+        # Cancel each task
+        foreach ($_task in $tasksToCancel) {
+            try {
+                Write-Verbose "Cancelling task: $($_task.Id) - $($_task.Description)"
+                $repo._repository.Tasks.Cancel($_task)
+            }
+            catch {
+                Write-Warning "Failed to cancel task $($_task.Id): $_"
+            }
+        }
+    }
+
+    end {
+        
+    }
+}


### PR DESCRIPTION
Add Stop-Task function to cancel tasks

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This function will cancel tasks in Octopus Deploy, depending on the filters given with the parameters.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We wanted to cancel several tasks in Octopus Deploy by just a few clicks, which is not possible by the GUI. You need to cancel every task by itself. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested the parameter 'Regarding' with a specific Project Release and a Snapshot of a Runbook.
I tested the parameter 'Task' with a TaskID like 'ServerTasks-*' and with an object of Octopus.TaskRecource type.
I tested also the parameters 'Tenant', 'Environment' and 'TaskType' all together and separate.
Of course the parameter 'State' was tested with all runs.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

