### PR TITLE
New function Set-RunbookSettings for setting +semver: minor

### DIFF
--- a/OctopusDeploy/Public/Set-RunbookSettings.ps1
+++ b/OctopusDeploy/Public/Set-RunbookSettings.ps1
@@ -1,0 +1,133 @@
+function Set-RunbookSettings {
+    <#
+    .SYNOPSIS
+        Sets the settings of a runbook. But not 'Deployment Target Status' and 'Default Failure Mode'
+    .DESCRIPTION
+        Sets the following settings of a runbook:
+        Name
+        Description
+        RunRetentionPolicy
+        EnvironmentScope
+        MultiTenancyMode
+        ForcePackageDownload
+    .PARAMETER Runbook
+        Specifies the runbook object to set the settings for.
+    .PARAMETER Name
+        Specifies the name of the runbook to set.
+    .PARAMETER Description
+        Specifies the description of the runbook.
+    .PARAMETER RunRetentionPolicy
+        Specifies the run retention policy of the runbook. Valid values are 0 (keep forever) and 1-10000 (number of runs to keep).
+    .PARAMETER EnvironmentScope
+        Specifies the environment scope of the runbook. Valid values are 'All', 'FromProjectLifecycles', and 'Specified'.
+        The parameter EnvironmentScope 'Specified' requires to manage the Environments in Octopus Deploy UI.
+    .PARAMETER MultiTenancyMode
+        Specifies the multi-tenancy mode of the runbook. Valid values are 'Tenanted', 'TenantedOrUntenanted', and 'Untenanted'.
+    .PARAMETER ForcePackageDownload
+        Specifies whether to force the package download for the runbook.
+    .EXAMPLE
+        Set-RunbookSettings -Runbook 'RunbookName' -Description 'New Description' -RunRetentionPolicy 1000 -MultiTenancyMode 'Tenanted'
+        Set-RunbookSettings -Runbook $runbookObj -EnvironmentScope 'Specified'
+        Set-RunbookSettings -Runbook $runbookObj -EnvironmentScope 'All'
+        Set-RunbookSettings -Runbook $runbookObj -RetentionPolicy 1000
+        Set-RunbookSettings -Runbook $runbookObj -Name 'DBMS Mig - DNA-000 - Draftbook' -Description 'This is just a draft' -MultiTenancyMode 'Tenanted'
+        Set-RunbookSettings -Runbook $runbookObj -ForcePackageDownload $true
+    #>
+    [CmdletBinding()]
+    param (
+        # Parameter help description
+
+        [Parameter(mandatory = $true,
+            Position = 0,
+            ValueFromPipeline = $true)]
+        [ValidateNotNullOrEmpty()]
+        [RunbookSingleTransformation()]
+        [Octopus.Client.Model.RunbookResource]
+        $Runbook,
+
+        [Parameter(mandatory = $false,
+            ValueFromPipelineByPropertyName = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Name,
+
+        [Parameter(mandatory = $false,
+            ValueFromPipelineByPropertyName = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Description,
+
+        [Parameter(mandatory = $false,
+            ValueFromPipelineByPropertyName = $true)]
+        [ValidateRange(0, 10000)]
+        [int]
+        $RetentionPolicy,
+
+        [Parameter(mandatory = $false,
+            ValueFromPipelineByPropertyName = $true)]
+        [ValidateSet('All', 'FromProjectLifecycles', 'Specified')]
+        [string]
+        $EnvironmentScope,
+
+        [Parameter(mandatory = $false,
+            ValueFromPipelineByPropertyName = $true)]
+        [ValidateSet('Tenanted', 'TenantedOrUntenanted', 'Untenanted')]
+        [string]
+        $MultiTenancyMode,
+
+        [Parameter(mandatory = $false,
+            ValueFromPipelineByPropertyName = $true)]
+        [bool]
+        $ForcePackageDownload
+    )
+    begin {
+        try {
+            ValidateConnection
+        } catch {
+            $PSCmdlet.ThrowTerminatingError($_)
+        }
+    }
+
+    process {
+        if ($Name) {
+            $Runbook.Name = $Name
+        }
+
+        if ($Description) {
+            $Runbook.Description = $Description
+        }
+
+        if ($PSBoundParameters.ContainsKey("RetentionPolicy")) {
+            if ($RetentionPolicy -eq 0) {
+                Write-Warning "Setting RetentionPolicy to 0 will keep runbooks forever. This is not recommended."
+                $Runbook.RunRetentionPolicy.ShouldKeepForever = $true
+            } else {
+                $Runbook.RunRetentionPolicy.ShouldKeepForever = $false
+            }
+            $Runbook.RunRetentionPolicy.QuantityToKeep = $RetentionPolicy
+            $Runbook.RunRetentionPolicy
+        }
+
+        if ($EnvironmentScope) {
+            if ($EnvironmentScope -eq 'Specified') {
+                Write-Warning "The parameter EnvironmentScope 'Specified' requires to manage the Environments in Octopus Deploy UI."
+            } else {
+                $Runbook.Environments.Clear()
+            }
+            $Runbook.EnvironmentScope = $EnvironmentScope
+        }
+
+        if ($MultiTenancyMode) {
+            $Runbook.MultiTenancyMode = $MultiTenancyMode
+        }
+        
+        if ($ForcePackageDownload) {
+            $Runbook.ForcePackageDownload = $ForcePackageDownload
+        }
+
+        $repo._repository.Runbooks.Modify($Runbook)
+
+    }
+    end {}
+}
+


### PR DESCRIPTION
Set the settings of a runbook in Octopus Deploy. +semver: minor

<!--- Provide a general summary of your changes in the Title above -->

## Description
The function Set-RunbookSettings sets the settings of a runbook, but not 'Deployment Target Status' and 'Default Failure Mode'

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
We wanted to be able to change the settings of several runbooks at the same time, so we needed a powershell function.

## How Has This Been Tested?
Tested how many settings can be set through the Octopus.Client.dll, these are some commands:
Set-RunbookSettings -Runbook $runbookObj -EnvironmentScope 'Specified'
Set-RunbookSettings -Runbook $runbookObj -EnvironmentScope 'All'
Set-RunbookSettings -Runbook $runbookObj -RetentionPolicy 1000
Set-RunbookSettings -Runbook $runbookObj -Name 'DBMS Mig - DNA-000 - Draftbook' -Description 'This is just a draft' -MultiTenancyMode 'Tenanted'
Set-RunbookSettings -Runbook $runbookObj -ForcePackageDownload $true

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

