### PR TITLE
Add space parameter to Get-Task function for improved path handling

### DIFF
--- a/OctopusDeploy/Public/Get-Task.ps1
+++ b/OctopusDeploy/Public/Get-Task.ps1
@@ -106,6 +106,10 @@
                 } else { return ($path + "&") }
             }
 
+            # always add space
+            $space = Get-CurrentSpace
+            $path = (checkpath $path) + "spaces=$($space.id)"
+
             # setting up searchlink
             if ($TaskType) { $path = (checkpath $path) + "name=$tasktype" }
             if ($Tenant) { $path = (checkpath $path) + "tenant=$($Tenant.id)" }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Get-Task now respects the space you are currently using. up until now get-task you get tasks from all spaces and ignore the current space setting


